### PR TITLE
Potential fix for code scanning alert no. 4: File is not always closed

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         include:
         - language: c-cpp
-          build-mode: autobuild
+          build-mode: none
         - language: go
           build-mode: autobuild
         - language: java-kotlin

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,8 +43,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: c-cpp
-          build-mode: none
+        # - language: c-cpp
+        #  build-mode: none
         - language: go
           build-mode: autobuild
         - language: java-kotlin

--- a/scripts/sort_contibutors/main.py
+++ b/scripts/sort_contibutors/main.py
@@ -8,11 +8,11 @@ import requests
 def print_file(s: str, flag: bool) -> None:
     # True for MD , false for HTML file
     if flag:
-        f = open("contributors_file.md", "w")
-        f.write(s)
+        with open("contributors_file.md", "w") as f:
+            f.write(s)
         return
-    f = open("contributors_file.html", "w")
-    f.write(s)
+    with open("contributors_file.html", "w") as f:
+        f.write(s)
 
 
 def print_md(user_list: dict, label="") -> str:


### PR DESCRIPTION
Potential fix for [https://github.com/avwolferen/wrongsecrets/security/code-scanning/4](https://github.com/avwolferen/wrongsecrets/security/code-scanning/4)

To fix the issue, we will use a `with` statement to open the file. The `with` statement ensures that the file is automatically closed when the block is exited, even if an exception occurs. This approach is cleaner and safer than manually calling `close`.

Specifically:
1. Replace the `open` calls on lines 11 and 14 with `with open(...) as f:` blocks.
2. Move the `write` operation inside the `with` block to ensure the file is closed after writing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
